### PR TITLE
Add Playwright test for login page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MediMove Demo</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+function App() {
+  const [loggedIn, setLoggedIn] = React.useState(false);
+  return (
+    <div>
+      {!loggedIn ? (
+        <div>
+          <h1>Anmeldung</h1>
+          <button onClick={() => setLoggedIn(true)}>Login</button>
+        </div>
+      ) : (
+        <div>Willkommen!</div>
+      )}
+    </div>
+  );
+}
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "projectfitcalc",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,0 +1,11 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// Basic test to ensure the demo page shows the login interface
+
+test('shows login form', async ({ page }) => {
+  const filePath = path.resolve(__dirname, '../index.html');
+  await page.goto('file://' + filePath);
+  await expect(page.getByRole('heading', { name: 'Anmeldung' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add a minimal React demo page with a login form
- add Playwright test verifying the login heading and button

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad854dc7c4832cad3743a61db0641a